### PR TITLE
fix: make sure auto announcements run

### DIFF
--- a/cogs/announcements_admin_cog.py
+++ b/cogs/announcements_admin_cog.py
@@ -81,22 +81,12 @@ class AnnouncementsAdminCog(commands.Cog):
 			# Attempt to fetch channel
 			try:
 				channel = await self.bot.fetch_channel(announcement["ChannelID"])
-			except discord.NotFound:
-				continue
-			except discord.Forbidden:
-				continue
 			except discord.HTTPException:
-				continue
-			finally:
 				continue
 
 			# Attempt to post
 			try:
 				await channel.send(content=announcement["Message"])
-			except discord.Forbidden:
-				continue
-			except discord.HTTPException:
-				continue
 			finally:
 				continue
 


### PR DESCRIPTION
### Bug or Request addressed
#27

### Demonstration
N/A

### Other comments
This PR adjusts the auto announcement logic to make sure they actually run and cuts down on the number of errors handled to the bare minimum.

As a little note:
- `discord.NotFound` and `discord.Forbidden` are subclasses of `discord.HTTPException` - you only really need to catch `discord.HTTPException` because the other two will be caught along with it, too.
- `finally` runs after a try-catch code is run regardless of if there were any errors or not. The `finally` used for the channel fetch meant that even if it did found the channel, it would just move on to the next announcement in the list rather than trying to post the current announcement... meaning no auto announcement would ever be posted 😅.

### Checklist
- [x] I have tested all my changes on a Discord bot application.
- [x] I have linted all my changes and made all reasonable adjustments.
- [ ] My credit is in `CONTRIBUTORS.md` (it'll be in another PR if any of my current PRs get merged).
- [ ] This PR has either the 'bug' or 'feature request' label on it (and'credit request' if applicable). - turns out I can't do this myself.