### PR TITLE
refactor: remove unnecessarily caught error

### DIFF
--- a/cogs/investigation_admin_cog.py
+++ b/cogs/investigation_admin_cog.py
@@ -167,8 +167,6 @@ class InvestigationAdminCog(commands.Cog):
 					channel_name = channels[i]
 				except discord.HTTPException:
 					channel_name = loc.response("investigate_admin", "list", "warning-nochannel", ctx.interaction.locale)
-				except discord.NotFound:
-					channel_name = loc.response("investigate_admin", "list", "warning-nochannel", ctx.interaction.locale)
 				except IndexError:
 					break
 


### PR DESCRIPTION
### Bug or Request addressed
N/A - let me know if an issue is *absolutely* required, because most of these are minor tweaks.

### Demonstration
N/A

### Other comments
This one just removes an unnecessarily caught error in a try-catch (or, well, try-except, my bad) block.

`discord.NotFound` is already caught by `discord.HTTPException`.

### Checklist
- [x] I have tested all my changes on a Discord bot application.
- [x] I have linted all my changes and made all reasonable adjustments.
- [ ] My credit is in `CONTRIBUTORS.md` (it'll be in another PR if any of my current PRs get merged).
- [ ] This PR has either the 'bug' or 'feature request' label on it (and'credit request' if applicable). - turns out I can't do this myself.