### PR TITLE
feat!: don't remove pycaches on exit

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,25 +36,6 @@ def app_died():
 
 	db.disconnect()
 
-	# Remove __pycache__
-	try:
-		shutil.rmtree("__pycache__")
-	except FileNotFoundError:
-		pass
-
-	try:
-		shutil.rmtree("./cogs/__pycache__")
-	except FileNotFoundError:
-		pass
-
-	try:
-		shutil.rmtree("./utils/__pycache__")
-	except FileNotFoundError:
-		pass
-
-	print("Removed __pycache__")
-
-
 # ------------------------------------------------------------------------
 # Essential event listeners
 # ------------------------------------------------------------------------


### PR DESCRIPTION
### Bug or Request addressed
#26 

### Demonstration
N/A

### Other comments
Python automatically creates a cache for files when they are run for the first time so that they can be run faster the second+ time around. This is a nice speedup and has little, if no, downsides.

For some reason, Ultimate Assistant removes them upon the program ending. This is both unnecessary, as the files are only helpful and do not get picked up thanks to the `.gitignore` (ideally, at least it won't with my `.gitignore` PR), but also means extra operations have to be done when booting up from scratch (and deleting files has some cost, too).

This PR gets rids of that. Let me know if you have concerns over removing it or if there's a valid reason to delete the caches - I think this may be worth talking about.

### Checklist
- [x] I have tested all my changes on a Discord bot application.
- [x] I have linted all my changes and made all reasonable adjustments.
- [ ] My credit is in `CONTRIBUTORS.md` (it'll be in another PR if any of my current PRs get merged).
- [ ] This PR has either the 'bug' or 'feature request' label on it (and'credit request' if applicable). - turns out I can't do this myself.