### PR TITLE
Revert "refactor: get dm channel on cog load"

### DIFF
--- a/cogs/developer_cog.py
+++ b/cogs/developer_cog.py
@@ -24,13 +24,8 @@ class DeveloperCog(commands.Cog):
 
 	def __init__(self, bot):
 		self.bot = bot
-		self.dm_channel = None # Cannot have async init
-		self.bot.loop.create_task(self.get_dm_channel()) # ...so instead we get it here
+		self.dm_channel = None # Cannot have async init, initialized on first use
 		print(f"Added {self.__class__.__name__}")
-
-	async def get_dm_channel(self):
-		dev_user = await self.bot.fetch_user(DEVELOPER_ID)
-		self.dm_channel = await dev_user.create_dm()
 
 
 # ------------------------------------------------------------------------
@@ -47,6 +42,11 @@ class DeveloperCog(commands.Cog):
 	async def on_guild_join(self, guild):
 		"""DM developer"""
 
+		if (not self.dm_channel):
+			dev_user = await self.bot.fetch_user(DEVELOPER_ID)
+			self.dm_channel = await dev_user.create_dm()
+
+
 		await self.dm_channel.send(f"Added to **{guild.name}** ({guild.id})")
 
 
@@ -54,12 +54,20 @@ class DeveloperCog(commands.Cog):
 	async def on_guild_remove(self, guild):
 		"""DM developer"""
 
+		if (not self.dm_channel):
+			dev_user = await self.bot.fetch_user(DEVELOPER_ID)
+			self.dm_channel = await dev_user.create_dm()
+
 		await self.dm_channel.send(f"Removed from **{guild.name}** ({guild.id})")
 
 
 	@commands.Cog.listener()
 	async def on_application_command_error(self, ctx, exception):
 		"""DM developer"""
+
+		if (not self.dm_channel):
+			dev_user = await self.bot.fetch_user(DEVELOPER_ID)
+			self.dm_channel = await dev_user.create_dm()
 
 
 		msg = f"**GuildID**: {ctx.guild.id}\n"


### PR DESCRIPTION
Ran the test branch on my machine and got this:
```
Task exception was never retrieved
future: <Task finished name='Task-1' coro=<DeveloperCog.get_dm_channel() done, defined at /mnt/d/Projects/Discord Bots/ultimate_assistant_pycord/cogs/developer_cog.py:31> exception=AttributeError("'_MissingSentinel' object has no attribute 'request'")>
Traceback (most recent call last):
  File "/mnt/d/Projects/Discord Bots/ultimate_assistant_pycord/cogs/developer_cog.py", line 32, in get_dm_channel
    dev_user = await self.bot.fetch_user(DEVELOPER_ID)
  File "/mnt/d/Projects/Discord Bots/venv/lib/python3.8/site-packages/discord/client.py", line 1570, in fetch_user
    data = await self.http.get_user(user_id)
  File "/mnt/d/Projects/Discord Bots/venv/lib/python3.8/site-packages/discord/http.py", line 284, in request
    async with self.__session.request(method, url, **kwargs) as response:
AttributeError: '_MissingSentinel' object has no attribute 'request'
```

I don't want to revert this change entirely since it's a nice, elegant solution, but something's not quite right