### PR TITLE
refactor: actually get dm channel on cog load

### DIFF
--- a/cogs/developer_cog.py
+++ b/cogs/developer_cog.py
@@ -23,9 +23,17 @@ class DeveloperCog(commands.Cog):
 	"""Developer utilities"""
 
 	def __init__(self, bot):
-		self.bot = bot
-		self.dm_channel = None # Cannot have async init, initialized on first use
+		self.bot: discord.Bot = bot
+		self.dm_channel = None # Cannot have async init
+		self.bot.loop.create_task(self.get_dm_channel()) # ...so instead we get it here
 		print(f"Added {self.__class__.__name__}")
+
+	async def get_dm_channel(self):
+		# This whole thing will break if this is run before the bot logs in
+		await self.bot.wait_until_ready()
+
+		dev_user = await self.bot.fetch_user(DEVELOPER_ID)
+		self.dm_channel = await dev_user.create_dm()
 
 
 # ------------------------------------------------------------------------
@@ -41,12 +49,6 @@ class DeveloperCog(commands.Cog):
 	@commands.Cog.listener()
 	async def on_guild_join(self, guild):
 		"""DM developer"""
-
-		if (not self.dm_channel):
-			dev_user = await self.bot.fetch_user(DEVELOPER_ID)
-			self.dm_channel = await dev_user.create_dm()
-
-
 		await self.dm_channel.send(f"Added to **{guild.name}** ({guild.id})")
 
 
@@ -54,21 +56,12 @@ class DeveloperCog(commands.Cog):
 	async def on_guild_remove(self, guild):
 		"""DM developer"""
 
-		if (not self.dm_channel):
-			dev_user = await self.bot.fetch_user(DEVELOPER_ID)
-			self.dm_channel = await dev_user.create_dm()
-
 		await self.dm_channel.send(f"Removed from **{guild.name}** ({guild.id})")
 
 
 	@commands.Cog.listener()
 	async def on_application_command_error(self, ctx, exception):
 		"""DM developer"""
-
-		if (not self.dm_channel):
-			dev_user = await self.bot.fetch_user(DEVELOPER_ID)
-			self.dm_channel = await dev_user.create_dm()
-
 
 		msg = f"**GuildID**: {ctx.guild.id}\n"
 		msg += f"**ChannelID**: {ctx.channel.id}\n"


### PR DESCRIPTION
#25, but with a little patch applied.

### Bug or Request addressed
N/A - let me know if an issue is *absolutely* required, because most of these are minor tweaks.

### Demonstration
N/A

### Other comments
Just using a fun (low level) part of `pycord` to load the DM channel immediately here instead of waiting for the first usage.

It should make things just that tiny bit faster.

### Checklist
- [x] I have tested all my changes on a Discord bot application.
- [x] I have linted all my changes and made all reasonable adjustments.
- [ ] My credit is in `CONTRIBUTORS.md` (it'll be in another PR if any of my current PRs get merged).
- [ ] This PR has either the 'bug' or 'feature request' label on it (and'credit request' if applicable). - turns out I can't do this myself.